### PR TITLE
:bug: Rename 3.0.0.yml to 4.0.0.yml

### DIFF
--- a/.github/workflows/4.0.0.yml
+++ b/.github/workflows/4.0.0.yml
@@ -1,4 +1,4 @@
-name: 🚀 Deploy 3.0.0
+name: 🚀 Deploy 4.0.0
 
 on:
   workflow_dispatch:
@@ -7,5 +7,5 @@ jobs:
   deploy:
     uses: libhal/ci/.github/workflows/deploy-all.yml@5.x.y
     with:
-      version: 3.0.0
+      version: 4.0.0
     secrets: inherit


### PR DESCRIPTION
The proper version for the libhal 3.0.0 release is 4.0.0 since 3.0.0 is already released for libhal-soft.