### PR TITLE
:white_check_mark: Fixup adc_mux & throws usage in tests

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -25,7 +25,6 @@ required_conan_version = ">=2.0.14"
 class libhal_soft_conan(ConanFile):
     name = "libhal-soft"
     license = "Apache-2.0"
-    url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://libhal.github.io/libhal-soft"
     description = (
         "Library for generic soft drivers officially supported by libhal")

--- a/tests/adc_mux.test.cpp
+++ b/tests/adc_mux.test.cpp
@@ -68,6 +68,18 @@ void adc_mux_test()
     expect(that % expected_sample_zero == test_sample);
   };
 
+  "adc_mux ctor failure due to too few mux pins"_test =
+    [signal_pins, source_adc, mock_timer]() mutable {
+      // Setup
+      expect(throws<hal::argument_out_of_domain>([&]() {
+        [[maybe_unused]] adc_multiplexer test_mux(
+          // Pass only the first element so the list is size of 1
+          std::span<hal::output_pin*>(signal_pins).first(1),
+          source_adc,
+          mock_timer);
+      }));
+    };
+
   // simulate reading from another pin
   "adc_mux_pin_switch"_test = [signal_pins, source_adc, mock_timer]() mutable {
     // Setup
@@ -98,16 +110,17 @@ void adc_mux_test()
     expect(that % true == second_signal_state.second);
   };
 
-  "adc_mux_error"_test = [signal_pins, source_adc, mock_timer]() mutable {
-    // Setup
-    adc_multiplexer test_mux(signal_pins, source_adc, mock_timer);
+  "make_adc(adc_mux, #count) error"_test =
+    [signal_pins, source_adc, mock_timer]() mutable {
+      // Setup
+      adc_multiplexer test_mux(signal_pins, source_adc, mock_timer);
 
-    // Exercise
-    // Verify
-    [[maybe_unused]] auto f = throws<hal::argument_out_of_domain>([&]() {
-      [[maybe_unused]] auto adc_pin = hal::make_adc(test_mux, 3).read();
-    });
-  };
+      // Exercise
+      // Verify
+      expect(throws<hal::argument_out_of_domain>([&]() {
+        [[maybe_unused]] auto adc_pin = hal::make_adc(test_mux, 4).read();
+      }));
+    };
 };
 
 }  // namespace hal::soft

--- a/tests/rc_servo.test.cpp
+++ b/tests/rc_servo.test.cpp
@@ -47,7 +47,7 @@ void rc_servo_test()
     pwm2.spy_frequency.trigger_error_on_call(
       1, []() { hal::safe_throw(hal::operation_not_supported(nullptr)); });
 
-    [[maybe_unused]] auto f = throws([&]() { rc_servo servo2(pwm2, {}); });
+    expect(throws([&]() { rc_servo servo2(pwm2, {}); }));
   };
 
   "hal::servo::rc_servo::position"_test = []() {
@@ -154,8 +154,8 @@ void rc_servo_test()
 
     // Exercise
     // Verify
-    [[maybe_unused]] auto f = throws<hal::argument_out_of_domain>(
-      [&]() { test.position(max_angle + 45.0f); });
+    expect(throws<hal::argument_out_of_domain>(
+      [&]() { test.position(max_angle + 45.0f); }));
   };
 };
 }  // namespace hal::soft


### PR DESCRIPTION
- Add additional input checks for hal::soft::adc_multiplexer's ctor and
  read_channel() functions.
- hal::soft::adc_mux_pin is now a friend of hal::soft::adc_multiplexer
  allowing it to directly set the adc mux pin without bounds checking.
  It is bounds checked at construction.