### PR TITLE
:ambulance: Fix initialization in bit_bang_i2c constructor

### DIFF
--- a/demos/applications/bit_bang_i2c.cpp
+++ b/demos/applications/bit_bang_i2c.cpp
@@ -30,19 +30,19 @@ void application(hardware_map_t& p_map)
   auto& scl = *p_map.scl;
   auto& sda = *p_map.sda;
 
-  hal::print(console, "Starting lis3dhtr_i2c Application...\n");
+  hal::print(
+    console,
+    "Starting bit bang i2c Application using a lis3dhtr_i2c driver...\n");
   hal::delay(clock, 50ms);
 
-  hal::bit_bang_i2c::pins pins{ .sda = &sda, .scl = &scl };
-
-  hal::bit_bang_i2c bit_bang_i2c(pins, clock);
+  hal::soft::bit_bang_i2c bit_bang_i2c({ .sda = &sda, .scl = &scl }, clock);
   bit_bang_i2c.configure(hal::i2c::settings{ .clock_rate = 100.0_kHz });
 
-  hal::stm_imu::lis3dhtr_i2c lis(bit_bang_i2c);
+  hal::stm_imu::lis3dhtr_i2c accelerometer(bit_bang_i2c);
 
   while (true) {
     hal::delay(clock, 500ms);
-    auto acceleration = lis.read();
+    auto const acceleration = accelerometer.read();
     hal::print<128>(console,
                     "Scale: 2g \t x = %fg, y = %fg, z = %fg \n",
                     acceleration.x,

--- a/include/libhal-soft/bit_bang_i2c.hpp
+++ b/include/libhal-soft/bit_bang_i2c.hpp
@@ -19,7 +19,7 @@
 #include <libhal/steady_clock.hpp>
 #include <libhal/units.hpp>
 
-namespace hal {
+namespace hal::soft {
 /**
  * @brief A bit bang implementation for i2c.
  *
@@ -29,7 +29,7 @@ namespace hal {
  * implementation meaning it will almost always run at a frequency which is less
  * then the request one but, never faster. The maximum achievable clock rate for
  * the lpc4078 is about 180kHz. Interrupts disrupt this controller because the
- * transfer is a blocking operation which means an interupt may come in the
+ * transfer is a blocking operation which means an interrupt may come in the
  * middle of a transaction and may leave a transaction hanging which some
  * peripherals may not support.
  */
@@ -45,15 +45,26 @@ public:
   /**
    * @brief Construct a new i2c bit bang object
    *
-   * @param p_pins This holds both scl and sda to be used inside of the driver
-   * @param p_steady_clock A steady clock that should have a higher frequency
-   * then the configured frequency for the bit bang
-   * @param p_duty_cycle The duty cycle that the clock, sent over scl, will run
-   * at
+   * @param p_pins named structure that contains pointers to the scl and sda to
+   * be used inside of the driver
+   * @param p_steady_clock the steady clock that will be used for timing the sda
+   * and scl lines. This should have a higher frequency then the i2c frequency
+   * that this device will be configured to.
+   * @param p_duty_cycle the clock duty cycle. Valid inputs are between 0.3 to
+   * 0.7. Outside of this range and the bit-bang i2c may lock up due to the
+   * shortness of the pulse duration.
+   * @param p_settings the initial settings of the i2c bus
+   *
+   * @throws hal::operation_not_supported if p_duty_cycle is below 0.3f or above
+   * 0.7f.
+   * @throws hal::operation_not_supported via driver_configure which may throw
+   * an exception if the operating speed is higher than the steady clock's
+   * frequency.
    */
   bit_bang_i2c(pins const& p_pins,
                steady_clock& p_steady_clock,
-               float const p_duty_cycle = 0.5f);
+               float const p_duty_cycle = 0.5f,
+               hal::i2c::settings const& p_settings = {});
 
 private:
   void driver_configure(settings const& p_settings) override;
@@ -133,7 +144,7 @@ private:
 
   /**
    * @brief This function will read in as many bytes as allocated inside of the
-   * span while also acking or nacking the data
+   * span while also ACKing or NACKing the data
    *
    * @param p_data_in A span which will be filled with the bytes that will be
    * read from the bus
@@ -153,31 +164,38 @@ private:
 
   /**
    * @brief This function is responsible for reading a single bit at a time. It
-   * will manage the clock and will release sda (pull it high) every time it is
-   * called
+   * will manage the clock and will release the sda pin (allow it to be pulled
+   * high) every time it is called
    *
-   * @return hal::byte which will house the single byte read from the bus
+   * @return hal::byte which will house the single bit read from the bus
    */
   hal::byte read_bit();
 
   /// @brief An output pin which is the i2c scl pin
-  output_pin* m_scl;
+  hal::output_pin* m_scl;
 
   /// @brief An output pin which is the i2c sda pin
-  output_pin* m_sda;
+  hal::output_pin* m_sda;
 
   /// @brief A steady_clock provides a mechanism to delay the clock pulses of
   /// the scl line.
-  steady_clock* m_clock;
+  hal::steady_clock* m_clock;
 
   /// @brief The time that scl will be held high for
-  uint64_t m_scl_high_ticks;
+  std::uint64_t m_scl_high_ticks;
 
   /// @brief The time that scl will be held low for
-  uint64_t m_scl_low_ticks;
+  std::uint64_t m_scl_low_ticks;
 
   /// @brief This is used to preserve the duty cycle that is passed in through
   /// the constructor and be used in the driver_configure function
   float m_duty_cycle;
 };
+}  // namespace hal::soft
+
+namespace hal {
+// This is here for backwards compatibility.
+// We made a mistake on the first review and accidentally put bit_bang_i2c in
+// the hal namespace.
+using hal::soft::bit_bang_i2c;
 }  // namespace hal


### PR DESCRIPTION
Critical bug fix in bit_bang_i2c that can lead to device damage. The output pins NEED to be set as open drain in order to not cause bus contention which can damage devices and cause short circuits.

The constructor now properly configures the sda and scl output pins and configures and performs initial configuration.

Resolves #36